### PR TITLE
Partie 4/chapitre 2 a

### DIFF
--- a/nightwatch/hello_world_test.js
+++ b/nightwatch/hello_world_test.js
@@ -9,9 +9,9 @@ module.exports = {
             .click('input[type=submit')
             .waitForElementVisible('.results--main')
             .assert.visible('#r1-0')
-            .assert.visible('#r1-0 .result__a')
-            .assert.containsText('#r1-0 .result__a', 'Hello world — Wikipédia')
-            .click('#r1-0 .result__a')
+            .assert.visible('#r1-0 a[data-testid="result-title-a"]')
+            .assert.containsText('#r1-0 a[data-testid="result-title-a"]', 'Hello world — Wikipédia')
+            .click('#r1-0 a[data-testid="result-title-a"]')
             .assert.visible('#firstHeading')
             .assert.containsText('#firstHeading', 'Hello world')
     }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "nightwatch": "^1.7.6"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "testNightWatch": "node_modules/.bin/nightwatch"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
La structure DOM de DuckDuckGo à l'air d'avoir changé, ce qui fait planter le test E2E; .result__a n'existe plus, mais a[data-testid="result-title-a"] peut le remplacer
Il est question dans le cours de la commande npm run testNightWatch, commande qui ne semble pas fonctionner sans l'ajout de la fonction dans le package.json